### PR TITLE
Lumina 2 and Gemma 2 model loading

### DIFF
--- a/library/strategy_lumina.py
+++ b/library/strategy_lumina.py
@@ -9,7 +9,9 @@ from library.strategy_base import (
     LatentsCachingStrategy,
     TokenizeStrategy,
     TextEncodingStrategy,
+    TextEncoderOutputsCachingStrategy
 )
+import numpy as np
 from library.utils import setup_logging
 
 setup_logging()

--- a/lumina_train_network.py
+++ b/lumina_train_network.py
@@ -345,7 +345,7 @@ class LuminaNetworkTrainer(train_network.NetworkTrainer):
 def setup_parser() -> argparse.ArgumentParser:
     parser = train_network.setup_parser()
     train_util.add_dit_training_arguments(parser)
-    lumina_train_utils.add_lumina_train_arguments(parser)
+    lumina_train_util.add_lumina_train_arguments(parser)
     return parser
 
 


### PR DESCRIPTION
https://huggingface.co/Alpha-VLLM/Lumina-Image-2.0/blob/main/text_encoder/config.json
https://huggingface.co/Alpha-VLLM/Lumina-Image-2.0/blob/main/transformer/config.json

I made a fp8 version of gemma 2 and lumina 2 on https://huggingface.co/rockerBOO/Lumina-Image-2.0-fp8_e4m3fn to test with. 

```
                    INFO     Building Lumina                                                                               lumina_util.py:31
                    INFO     Loading state dict from /home/rockerboo/sd/models/lumina-image-2.safetensors                  lumina_util.py:35
                    INFO     Loaded Lumina: <All keys matched successfully>                                                lumina_util.py:40
                    INFO     Building Gemma2                                                                               lumina_util.py:70
                    INFO     Loading state dict from /home/rockerboo/sd/text_encoders/gemma-2-2b.safetensors              lumina_util.py:112
2025-02-15 15:02:34 INFO     Loaded Gemma2: <All keys matched successfully>                                               lumina_util.py:124
                    INFO     Building AutoEncoder                                                                          lumina_util.py:49
                    INFO     Loading state dict from /mnt/900/vae/ae.safetensors                                           lumina_util.py:54
                    INFO     Loaded AE: <All keys matched successfully>                                                    lumina_util.py:59
```

I converted their .pth file into safetensors here https://huggingface.co/rockerBOO/lumina-image-2/blob/main/lumina-image-2.safetensors

Related: https://github.com/kohya-ss/sd-scripts/pull/1927